### PR TITLE
Update ClientCreateParams.cs

### DIFF
--- a/src/Tor/ClientCreateParams.cs
+++ b/src/Tor/ClientCreateParams.cs
@@ -192,9 +192,6 @@ namespace Tor
             builder.Append("--allow-missing-torrc ");
             builder.AppendFormat("--ControlPort {0}", controlPort);
 
-            /** TEMPORARY: DELETE LATER **/
-            builder.AppendFormat(" --SocksPort 9050");
-
             if (!string.IsNullOrWhiteSpace(configurationFile))
                 builder.AppendFormat(" -f \"{0}\"", configurationFile);
 


### PR DESCRIPTION
Removed those lines

/** TEMPORARY: DELETE LATER **/
builder.AppendFormat(" --SocksPort 9050");

as it prevents to use the SetConfig(ConfigurationNames.SocksPort, Port0 --> 2 command would be append and it would crash.